### PR TITLE
feat: remove body-parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "dependencies": {
         "axios": "1.7.4",
-        "body-parser": "1.20.2",
         "cors": "^2.8.5",
         "express": "4.19.2",
         "express-rate-limit": "7.4.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "axios": "1.7.4",
-    "body-parser": "1.20.2",
     "cors": "^2.8.5",
     "express": "4.19.2",
     "express-rate-limit": "7.4.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import bodyParser from "body-parser";
 import express from "express";
 import basicAuthMiddleware from "./middleware/basic-auth-middleware";
 import corsMiddleware from "./middleware/cors";
@@ -15,8 +14,7 @@ export const config: Config = parseConfig();
 const app = express();
 const port = 3000;
 
-app.use(bodyParser.urlencoded({ extended: true }));
-app.use(express.json());
+app.use(express.json({ limit: '10mb'}));
 app.use(corsMiddleware(config));
 app.use(rateLimitMiddleware(config));
 app.use(basicAuthMiddleware(config));


### PR DESCRIPTION
Using the `bodyParser.urlencoded({ extended: true})` middleware generates an `413: Payload too large` error when larges `body` objects are being processed. I looked a bit into it, and according to https://expressjs.com/de/api.html#express.json, body-parser is included in recent versions of `express` and can be used via `express.json()` instead. Doing that fixes the error.